### PR TITLE
Fix: Uncomment correct-answer-on-mistake element

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         <main class="main-content">
             <p id="instruction-text" class="instruction-text">Type the Romaji for the character below.</p>
             <div id="hiragana-display" class="hiragana-display rounded-box">あ</div>
-       <!--     <p id="correct-answer-on-mistake" class="correct-answer-on-mistake"></p> -->
+            <p id="correct-answer-on-mistake" class="correct-answer-on-mistake"></p>
             
             <form id="answer-form" class="answer-form">
                 <input type="text" id="romaji-input" class="text-input" placeholder="Type Romaji here..." autofocus autocomplete="off">


### PR DESCRIPTION
This resolves a TypeError in the checkAnswer function that occurred when trying to access the textContent of a null object. The HTML element was previously commented out, causing getElementById to return null.

This fix allows the application to correctly process answers and progress to the next question.