### PR TITLE
Fix: Robust lowercase input for Romaji field

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             <div id="hiragana-display" class="hiragana-display rounded-box">あ</div>
             
             <form id="answer-form" class="answer-form">
-                <input type="text" id="romaji-input" class="text-input" placeholder="Type Romaji here..." autofocus autocomplete="off">
+                <input type="text" id="romaji-input" class="text-input" placeholder="Type Romaji here..." autofocus autocomplete="off" autocapitalize="none">
                 <button type="submit" class="btn btn-primary submit-btn">Check</button>
             </form>
 

--- a/main.js
+++ b/main.js
@@ -1045,9 +1045,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- EVENT LISTENERS ---
 
-    elements.input.addEventListener('input', () => {
+    const forceLowercase = () => {
         elements.input.value = elements.input.value.toLowerCase();
-    });
+    };
+
+    elements.input.addEventListener('input', forceLowercase);
+    elements.input.addEventListener('keyup', forceLowercase); // Additional check
+    elements.input.addEventListener('change', forceLowercase); // Check when focus is lost
 
     elements.form.addEventListener('submit', (event) => {
         event.preventDefault(); 


### PR DESCRIPTION
Added `autocapitalize="none"` to the input element and included `keyup` and `change` event listeners in JavaScript to ensure consistent lowercase input, especially on mobile devices.